### PR TITLE
Add self installer script for Black Anvil

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,16 @@ cargo build --release
 # The binary will be available at ./target/release/black-anvil
 ```
 
+### Self-installer
+
+Build and install Black Anvil using the project itself:
+
+```bash
+./scripts/self_installer.sh /usr/local/bin
+```
+
+The argument specifies the installation directory and defaults to `/usr/local/bin`.
+
 ### Building the Tauri Frontend
 
 ```bash

--- a/scripts/self_installer.sh
+++ b/scripts/self_installer.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Self-installer for Black Anvil.
+# Builds Black Anvil and uses it to install itself with default settings.
+set -euo pipefail
+
+INSTALL_DIR="${1:-/usr/local/bin}"
+
+echo "Building Black Anvil..."
+cargo build --release
+
+CONFIG_FILE="$(mktemp)"
+cat > "$CONFIG_FILE" <<CONFIG
+project_path = "."
+build_type = "release"
+install_dir = "$INSTALL_DIR"
+vendor = false
+CONFIG
+
+echo "Installing Black Anvil to $INSTALL_DIR..."
+./target/release/black-anvil "$CONFIG_FILE"
+rm "$CONFIG_FILE"
+
+echo "Black Anvil installed to $INSTALL_DIR"


### PR DESCRIPTION
## Summary
- add `scripts/self_installer.sh` that builds and installs Black Anvil using itself
- document the self-installer in `README.md`

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_689e2b378e348322925479832aaddb3b